### PR TITLE
Fix Realtime Scanner crashing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission
         android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
@@ -65,6 +66,7 @@
         <service
             android:name=".MalwareScannerService"
             android:enabled="true"
+            android:foregroundServiceType="specialUse"
             android:exported="false"
             android:label="Realtime Malware Scanner" />
 

--- a/app/src/main/java/us/spotco/malwarescanner/Utils.java
+++ b/app/src/main/java/us/spotco/malwarescanner/Utils.java
@@ -141,6 +141,7 @@ class Utils {
             if (autostart) {
                 Intent realtimeScanner = new Intent(context, MalwareScannerService.class);
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    realtimeScanner.putExtra("foregroundServiceType", "FOREGROUND_SERVICE_TYPE_SPECIAL_USE");
                     context.startForegroundService(realtimeScanner);
                 } else {
                     context.startService(realtimeScanner);


### PR DESCRIPTION
The crash that was brought up in https://github.com/MaintainTeam/Hypatia/pull/38#issuecomment-2719135968 was being caused by the Foreground service not having a specified type. This pr fixes that. I am guessing that this changed recently, and when the sdk was updated, this was then required. 