### PR TITLE
Request permissions for accessing external storage on Android 13+.

### DIFF
--- a/app/src/main/java/us/spotco/malwarescanner/MainActivity.java
+++ b/app/src/main/java/us/spotco/malwarescanner/MainActivity.java
@@ -52,6 +52,9 @@ import androidx.appcompat.widget.Toolbar;
 import java.io.File;
 import java.util.HashSet;
 
+import java.util.List;
+import java.util.ArrayList;
+
 public class MainActivity extends AppCompatActivity {
 
     private SharedPreferences prefs = null;
@@ -70,6 +73,7 @@ public class MainActivity extends AppCompatActivity {
 
     private static final int REQUEST_PERMISSION_EXTERNAL_STORAGE = 0;
     private static final int REQUEST_PERMISSION_POST_NOTIFICATIONS = 0;
+    private static final int REQUEST_PERMISSION_READ_MEDIA = 0;
 
     @Override
     protected final void onCreate(Bundle savedInstanceState) {
@@ -150,6 +154,24 @@ public class MainActivity extends AppCompatActivity {
                         REQUEST_PERMISSION_POST_NOTIFICATIONS);
             }
         }
+        if (SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            List<String> permissionsNeeded = new ArrayList<>();
+
+            if (checkSelfPermission(Manifest.permission.READ_MEDIA_IMAGES) != PackageManager.PERMISSION_GRANTED) {
+                permissionsNeeded.add(Manifest.permission.READ_MEDIA_IMAGES);
+            }
+            if (checkSelfPermission(Manifest.permission.READ_MEDIA_AUDIO) != PackageManager.PERMISSION_GRANTED) {
+                permissionsNeeded.add(Manifest.permission.READ_MEDIA_AUDIO);
+            }
+            if (checkSelfPermission(Manifest.permission.READ_MEDIA_VIDEO) != PackageManager.PERMISSION_GRANTED) {
+                permissionsNeeded.add(Manifest.permission.READ_MEDIA_VIDEO);
+            }
+
+            if (!permissionsNeeded.isEmpty()) {
+                requestPermissions(permissionsNeeded.toArray(new String[0]), REQUEST_PERMISSION_READ_MEDIA);
+            }
+        }
+
         if (SDK_INT >= Build.VERSION_CODES.M) {
             if (checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
                 requestPermissions(new String[] { Manifest.permission.READ_EXTERNAL_STORAGE },


### PR DESCRIPTION
Partially satisfies #50, by requesting permissions to access images, audio and video. Please make sure the code is good, Java is still pretty new to me. Also, I don't have a device that runs an older android than 13, so if you could test that, that would be great.

This does not solve external storage not being scanned, that is a separate issue.

Also, when this app is published in Google Play, these permissions may cause problems. I recently read Google Play is really doubling down on apps with these permissions.