### PR TITLE
Log matches and domains in main app screen.

### DIFF
--- a/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.java
+++ b/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.java
@@ -148,10 +148,16 @@ public class LinkScannerService extends AccessibilityService {
             scannedDomains.add(domain);
             if (Database.domains.mightContain(domain)) {
                 sendNotification(domain);
+                logDomains(domain);
             }
         }
     }
-
+    private void logDomains(String link) {
+        link = link.replaceAll("\\.", "[.]");
+        HypatiaLogger.Log(getString(R.string.lblNotificationLinkDetection));
+        HypatiaLogger.Log("\"Domain:\" + link");
+        HypatiaLogger.Log(getString(R.string.see_notifications) + "\n");
+    }
     private void sendNotification(String link) {
         link = link.replaceAll("\\.", "[.]");
         Notification.Builder mBuilder =

--- a/app/src/main/java/us/spotco/malwarescanner/MalwareScanner.java
+++ b/app/src/main/java/us/spotco/malwarescanner/MalwareScanner.java
@@ -86,6 +86,11 @@ class MalwareScanner extends AsyncTask<HashSet<File>, Object, String> {
             if (isCache) {
                 malwareDetect[1] = context.getString(R.string.cache_scan_result_deletion_warning);
             }
+
+            HypatiaLogger.Log(context.getText(R.string.lblNotificationRealtimeDetection) + " " + malwareDetect[0]);
+            HypatiaLogger.Log("File:" + malwareDetect[1]);
+            HypatiaLogger.Log(context.getString(R.string.see_notifications) + "\n");
+
             Notification.Builder mBuilder =
                     new Notification.Builder(context.getApplicationContext())
                             .setSmallIcon(R.drawable.ic_notification)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,4 +85,5 @@
     <string name="confirm_link_scanner_title">Enable link scanner?</string>
     <string name="confirm_link_scanner_summary">[EXPERIMENTAL]\nThis will download an additional database of domains.\nAny domains found in screen content will be checked against the database.\nThis requires granting accessibility service permission manually.\nThis can have a substantial performance impact on screens with large amounts of text.</string>
     <string name="cache_scan_result_deletion_warning">Since this was a share scan you should manually remove or quarantine the file!</string>
+    <string name="see_notifications">Please see Notifications to manage the infected file.</string>
 </resources>


### PR DESCRIPTION
This logs all matches in the main app screen. I succesfully tested it with the file scanning. I was unable to test if it worked with the link scanner, as that currently doesn't work. Here is what it looks like: 
![Screenshot_20250409-181423](https://github.com/user-attachments/assets/d83e6d29-fd88-4815-809c-0b3fa6ecf9f9)

Does that look good? Is it easy enough to read?
This partially satisfies #30. It isn't everything requested but it is a start. 
Closes #25.