### PR TITLE
Various improvements to link scanning

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -78,6 +78,7 @@
         <service
             android:name=".LinkScannerService"
             android:exported="false"
+            android:foregroundServiceType="specialUse"
             android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
             android:label="@string/accessibility_service_label">
             <intent-filter>

--- a/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.kt
+++ b/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.kt
@@ -175,9 +175,9 @@ class LinkScannerService : AccessibilityService() {
     }
 
     companion object {
-        private const val hostnameRegex =
-            "^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,6}$" //Credit: http://www.mkyong.com/regular-expressions/domain-name-regular-expression-example/
-        private val hostnamePattern: Pattern = Pattern.compile(hostnameRegex)
+        private const val HOSTNAME_REGEX =
+            "^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[a-zA-Z0-9]{2,63}$" //Credit: http://www.mkyong.com/regular-expressions/domain-name-regular-expression-example/
+        private val hostnamePattern: Pattern = Pattern.compile(HOSTNAME_REGEX)
         private val scannedPackages = ConcurrentSkipListMap<String?, Long?>()
         private val scannerThreads = ConcurrentSkipListMap<String?, Thread?>()
 

--- a/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.kt
+++ b/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.kt
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 package us.spotco.malwarescanner
 
 import android.accessibilityservice.AccessibilityService
+import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -34,6 +35,7 @@ import java.util.concurrent.ConcurrentSkipListSet
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
+@SuppressLint("AccessibilityPolicy")
 class LinkScannerService : AccessibilityService() {
     private var notificationManager: NotificationManager? = null
 

--- a/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.kt
+++ b/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.kt
@@ -22,12 +22,14 @@ import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.content.SharedPreferences
 import android.os.Build
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import us.spotco.malwarescanner.HypatiaLogger.Companion.log
+import us.spotco.malwarescanner.Utils.context
 import java.util.Locale
 import java.util.Random
 import java.util.concurrent.ConcurrentSkipListMap
@@ -38,23 +40,37 @@ import java.util.regex.Pattern
 @SuppressLint("AccessibilityPolicy")
 class LinkScannerService : AccessibilityService() {
     private var notificationManager: NotificationManager? = null
+    private var foregroundNotification: NotificationCompat.Builder? = null
 
     public override fun onServiceConnected() {
+        prefs = context?.getSharedPreferences(BuildConfig.APPLICATION_ID, MODE_PRIVATE)
         notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager?
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // Create Detection Channel
             val detectionChannel = NotificationChannel(
                 "DETECTION",
                 getString(R.string.lblNotificationMalwareDetectionTitle),
                 NotificationManager.IMPORTANCE_HIGH
             )
             detectionChannel.description = getString(R.string.lblNotificationMalwareDetectionDescription)
-            notificationManager!!.createNotificationChannel(detectionChannel)
+            notificationManager?.createNotificationChannel(detectionChannel)
+
+            // Create Foreground Channel
+            val foregroundChannel = NotificationChannel(
+                "FOREGROUND",
+                getString(R.string.lblLinkScannerToggle),
+                NotificationManager.IMPORTANCE_LOW
+            )
+            foregroundChannel.description = getString(R.string.link_scanner_notification_description)
+            foregroundChannel.setShowBadge(false)
+            notificationManager?.createNotificationChannel(foregroundChannel)
         }
         checkDomainDatabaseStatus()
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent) {
         if (Database.isDomainDatabaseLoaded) {
+            setForegroundNotification(getString(R.string.link_scanner_notification_text))
             var shouldScanView = true
             var packageName = event.packageName as String?
             if (event.source != null) {
@@ -84,6 +100,7 @@ class LinkScannerService : AccessibilityService() {
                 thread.start()
             }
         }
+        stopForegroundNotification()
     }
 
     override fun onInterrupt() {
@@ -97,6 +114,7 @@ class LinkScannerService : AccessibilityService() {
                 Toast.LENGTH_LONG
             ).show()
             log(getString(R.string.database_not_loaded_link_scanner) + "\n")
+            setForegroundNotification(getString(R.string.database_not_loaded_link_scanner))
         }
     }
 
@@ -188,6 +206,32 @@ class LinkScannerService : AccessibilityService() {
         notificationManager!!.notify(Random().nextInt(), mBuilder.build())
     }
 
+    private fun setForegroundNotification(message: String) {
+        val channelId = "FOREGROUND"
+        foregroundNotification =
+            NotificationCompat.Builder(this, channelId)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setContentTitle(getText(R.string.lblLinkScannerToggle))
+                .setContentText(message)
+                .setPriority(NotificationCompat.PRIORITY_MIN)
+                .setOngoing(true)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            foregroundNotification?.setShowWhen(false)
+        }
+
+        startForeground(-1, foregroundNotification?.build())
+    }
+
+    private fun stopForegroundNotification() {
+        if (!prefs!!.getBoolean("DOMAINS", false) && foregroundNotification != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+            } else {
+                stopForeground(true)
+            }
+        }
+    }
+
     companion object {
         private const val HOSTNAME_REGEX =
             "^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[a-zA-Z0-9]{2,63}$" //Credit: http://www.mkyong.com/regular-expressions/domain-name-regular-expression-example/
@@ -197,5 +241,6 @@ class LinkScannerService : AccessibilityService() {
 
         private val scannedText = ConcurrentSkipListSet<Int?>()
         private val scannedDomains = ConcurrentSkipListSet<String?>()
+        private var prefs: SharedPreferences? = null
     }
 }

--- a/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.kt
+++ b/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.kt
@@ -24,6 +24,7 @@ import android.app.NotificationManager
 import android.os.Build
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
+import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import us.spotco.malwarescanner.HypatiaLogger.Companion.log
 import java.util.Locale
@@ -47,6 +48,7 @@ class LinkScannerService : AccessibilityService() {
             detectionChannel.description = getString(R.string.lblNotificationMalwareDetectionDescription)
             notificationManager!!.createNotificationChannel(detectionChannel)
         }
+        checkDomainDatabaseStatus()
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent) {
@@ -83,6 +85,17 @@ class LinkScannerService : AccessibilityService() {
     }
 
     override fun onInterrupt() {
+    }
+
+    private fun checkDomainDatabaseStatus() {
+        if (Database.domains == null){
+            Toast.makeText(
+                this,
+                getString(R.string.database_not_loaded_link_scanner),
+                Toast.LENGTH_LONG
+            ).show()
+            log(getString(R.string.database_not_loaded_link_scanner) + "\n")
+        }
     }
 
     private fun scanViews(mNodeInfo: AccessibilityNodeInfo?) {

--- a/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.kt
+++ b/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.kt
@@ -95,7 +95,13 @@ class LinkScannerService : AccessibilityService() {
             }
             if (shouldScanView) {
                 scannedPackages.put(packageName, System.currentTimeMillis())
-                val thread = Thread { scanViews(event.source) }
+                val sourceCopy = event.source?.let {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+                        AccessibilityNodeInfo(it)
+                    else
+                        AccessibilityNodeInfo.obtain(it)
+                }
+                val thread = Thread { scanViews(sourceCopy) }
                 scannerThreads.put(packageName, thread)
                 thread.start()
             }

--- a/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.kt
+++ b/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.kt
@@ -54,7 +54,7 @@ class LinkScannerService : AccessibilityService() {
             var shouldScanView = true
             var packageName = event.packageName as String?
             if (event.source != null) {
-                packageName += event.source!!.className
+                packageName += event.source?.className
             }
             if (scannedPackages.containsKey(packageName)) {
                 if ((System.currentTimeMillis() - scannedPackages.get(packageName)!!) < 1000) {

--- a/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.kt
+++ b/app/src/main/java/us/spotco/malwarescanner/LinkScannerService.kt
@@ -151,8 +151,7 @@ class LinkScannerService : AccessibilityService() {
     private fun logDomains(link: String) {
         var link = link
         link = link.replace("\\.".toRegex(), "[.]")
-        log(getString(R.string.lblNotificationLinkDetection))
-        log("\"Domain:\" + $link")
+        log("${getString(R.string.lblNotificationLinkDetection)} $link")
         log(getString(R.string.see_notifications) + "\n")
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
     <string name="lblLinkScannerToggle">Link Scanner</string>
     <string name="confirm_link_scanner_title">Enable link scanner?</string>
     <string name="confirm_link_scanner_summary">[EXPERIMENTAL]\nThis will download an additional database of domains.\nAny domains found in screen content will be checked against the database.\nThis requires granting accessibility service permission manually.\nThis can have a substantial performance impact on screens with large amounts of text.</string>
+    <string name="database_not_loaded_link_scanner">No database loaded. Please update databases to use the link scanner.</string>
     <string name="cache_scan_result_deletion_warning">Since this was a share scan you should manually remove or quarantine the file!</string>
     <string name="see_notifications">Please see Notifications to manage the infected file.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,8 @@
     <string name="confirm_link_scanner_title">Enable link scanner?</string>
     <string name="confirm_link_scanner_summary">[EXPERIMENTAL]\nThis will download an additional database of domains.\nAny domains found in screen content will be checked against the database.\nThis requires granting accessibility service permission manually.\nThis can have a substantial performance impact on screens with large amounts of text.</string>
     <string name="database_not_loaded_link_scanner">No database loaded. Please update databases to use the link scanner.</string>
+    <string name="link_scanner_notification_text">Screen will be scanned and malicious links will be detected in realtime</string>
+    <string name="link_scanner_notification_description">Used to show link scanning information.</string>
     <string name="cache_scan_result_deletion_warning">Since this was a share scan you should manually remove or quarantine the file!</string>
     <string name="see_notifications">Please see Notifications to manage the infected file.</string>
 </resources>


### PR DESCRIPTION
- 087e1d28730c716123fa0ec6fb4a928a7fe3aba5: Update regex to better match domains
- 7ddd05314a423d89ac9216350194057168c5e38a: Fix potential NPE
- 88d068658fa825e37bb0a481d7983c44c3b7b5dd: Improve the logging of domains, it was pretty ugly before
- d7c918368a0f12816e6327c0eb30695b71a3da46: Show toast and log when no database loaded, that way people can know to update databases for link scanning
- e7da81c3f8802f25493b62641810b41b73889cab: Suppress lint warnings
- 317af584ab09892fec0f88b1c59c0737b245bd3e: Add various notifications for the link scanner. (A permanent foreground notification that updates based on link scanner status)
- 03573a2ed3e615f7af9755283b7133acdc42bdb6: Fix potential crash in accessibility node info.